### PR TITLE
Refactor KNNEstimator

### DIFF
--- a/src/estimates/frequentist.rs
+++ b/src/estimates/frequentist.rs
@@ -547,14 +547,14 @@ mod tests {
 
         // Estimate.
         // 11)
-        freq.add_example(train_x.row(0), train_y[0]);
+        freq.add_example(&train_x.row(0), train_y[0]);
         assert_eq!(freq.joint_count.get(&0).unwrap().count, vec![1, 0, 0]);
         assert_eq!(freq.joint_count.get(&0).unwrap().predict().unwrap(), 0);
         assert_eq!(freq.priors_count.count, vec![1, 0, 0]);
         assert_eq!(freq.error_count, 6);
 
         // 10)
-        freq.add_example(train_x.row(1), train_y[1]);
+        freq.add_example(&train_x.row(1), train_y[1]);
         assert_eq!(freq.joint_count.get(&0).unwrap().count, vec![1, 1, 0]);
         assert_eq!(freq.priors_count.count, vec![1, 1, 0]);
         //assert_eq!(freq.error_count, 2);
@@ -565,7 +565,7 @@ mod tests {
         assert_eq!(freq.error_count, 6);
 
         // 9)
-        freq.add_example(train_x.row(2), train_y[2]);
+        freq.add_example(&train_x.row(2), train_y[2]);
         assert_eq!(freq.joint_count.get(&1).unwrap().count, vec![0, 0, 0]);
         assert!(freq.joint_count.get(&1).unwrap().predict().is_none());
         assert_eq!(freq.priors_count.count, vec![1, 2, 0]);
@@ -573,14 +573,14 @@ mod tests {
 
 
         // 8)
-        freq.add_example(train_x.row(3), train_y[3]);
+        freq.add_example(&train_x.row(3), train_y[3]);
         assert_eq!(freq.joint_count.get(&1).unwrap().count, vec![0, 0, 1]);
         assert_eq!(freq.joint_count.get(&1).unwrap().predict().unwrap(), 2);
         assert_eq!(freq.priors_count.count, vec![1, 2, 1]);
         assert_eq!(freq.error_count, 3);
 
         // 7)
-        freq.add_example(train_x.row(4), train_y[4]);
+        freq.add_example(&train_x.row(4), train_y[4]);
         assert_eq!(freq.joint_count.get(&2).unwrap().count, vec![0, 0, 0]);
         // Starts predicting with priors also for 2.
         assert!(freq.joint_count.get(&2).unwrap().predict().is_none());
@@ -588,14 +588,14 @@ mod tests {
         assert_eq!(freq.error_count, 3);
 
         // 6)
-        freq.add_example(train_x.row(5), train_y[5]);
+        freq.add_example(&train_x.row(5), train_y[5]);
         assert_eq!(freq.joint_count.get(&2).unwrap().count, vec![0, 1, 0]);
         assert_eq!(freq.joint_count.get(&2).unwrap().predict().unwrap(), 1);
         assert_eq!(freq.priors_count.count, vec![1, 3, 2]);
         assert_eq!(freq.error_count, 3);
 
         // 5)
-        freq.add_example(train_x.row(6), train_y[6]);
+        freq.add_example(&train_x.row(6), train_y[6]);
         assert_eq!(freq.joint_count.get(&2).unwrap().count, vec![0, 1, 1]);
         //assert_eq!(freq.joint_count.get(&2).unwrap().predict().unwrap(), 2);
         let pred = freq.joint_count.get(&2).unwrap().predict().unwrap();
@@ -610,14 +610,14 @@ mod tests {
         assert!(freq.error_count == 3);
 
         // 4)
-        freq.add_example(train_x.row(7), train_y[7]);
+        freq.add_example(&train_x.row(7), train_y[7]);
         assert_eq!(freq.joint_count.get(&2).unwrap().count, vec![0, 1, 2]);
         assert_eq!(freq.joint_count.get(&2).unwrap().predict().unwrap(), 2);
         assert_eq!(freq.priors_count.count, vec![1, 3, 4]);
         assert_eq!(freq.error_count, 4);
 
         // 3)
-        freq.add_example(train_x.row(8), train_y[8]);
+        freq.add_example(&train_x.row(8), train_y[8]);
         assert_eq!(freq.joint_count.get(&2).unwrap().count, vec![1, 1, 2]);
         assert_eq!(freq.joint_count.get(&2).unwrap().predict().unwrap(), 2);
         assert_eq!(freq.priors_count.count, vec![2, 3, 4]);
@@ -625,7 +625,7 @@ mod tests {
         assert_eq!(freq.error_count, 4);    // Increases because of priors.
 
         // 2)
-        freq.add_example(train_x.row(9), train_y[9]);
+        freq.add_example(&train_x.row(9), train_y[9]);
         assert_eq!(freq.joint_count.get(&2).unwrap().count, vec![1, 2, 2]);
         let pred = freq.joint_count.get(&2).unwrap().predict().unwrap();
         // More properly it should be: assert!(pred == 1 || pred == 2);
@@ -635,12 +635,12 @@ mod tests {
         assert_eq!(freq.error_count, 4);
 
         // 1)
-        freq.add_example(train_x.row(10), train_y[10]);
+        freq.add_example(&train_x.row(10), train_y[10]);
         assert_eq!(freq.priors_count.count, vec![2, 5, 4]);
         assert_eq!(freq.error_count, 3);
 
         // 0)
-        freq.add_example(train_x.row(11), train_y[11]);
+        freq.add_example(&train_x.row(11), train_y[11]);
         assert_eq!(freq.error_count, 3);
         assert_eq!(freq.priors_count.count, vec![2, 6, 4]);
     }

--- a/src/estimates/knn.rs
+++ b/src/estimates/knn.rs
@@ -411,6 +411,8 @@ where D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64 {
     // max_k nearest neighbors for each test object.
     neighbors: Vec<NearestNeighbors<D>>,
     // Error for each test object.
+    // TODO: we could have bit vectors (e.g., Vec<bool> or BitVec)
+    // for errors. This should (very slightly) improve memory performance.
     pub errors: Vec<f64>,
     // Current prediction for each test label.
     pub predictions: Vec<Label>,

--- a/src/estimates/knn.rs
+++ b/src/estimates/knn.rs
@@ -413,7 +413,7 @@ where D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64 {
     // Error for each test object.
     // TODO: we could have bit vectors (e.g., Vec<bool> or BitVec)
     // for errors. This should (very slightly) improve memory performance.
-    pub errors: Vec<f64>,
+    pub errors: Vec<u32>,
     // Current prediction for each test label.
     pub predictions: Vec<Label>,
     // True test labels.
@@ -421,7 +421,7 @@ where D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64 {
     // Last queried k.
     current_k: usize,
     // k-NN count, for k = current_k.
-    pub k_error_count: f64,
+    pub k_error_count: u32,
     // Size of training data. The next training example to be removed by
     // remove_one() is n-1. The next training example to be added by
     // add_example() is n-1.
@@ -447,7 +447,7 @@ where D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64 + Send + Sync + Copy {
         // predictions (and errors, k_error_count, ...) to an Option value.
         // TODO: should we?
         let errors = test_y.iter()
-                           .map(|y| if *y != 0 { 1. } else { 0. })
+                           .map(|y| if *y != 0 { 1 } else { 0 })
                            .collect::<Vec<_>>();
         let error_count = errors.iter().sum();
         KNNEstimator {
@@ -480,14 +480,14 @@ where D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64 + Send + Sync + Copy {
                                                            distance))
                             .collect::<Vec<_>>();
 
-        let mut knn_error = 0.;
+        let mut knn_error = 0;
         let mut errors = Vec::with_capacity(test_y.len());
         let mut predictions = Vec::with_capacity(test_y.len());
 
         for (neigh, y) in neighbors.iter().zip(test_y) {
             let pred = neigh.predict(k)
                             .expect("unexpected error");
-            let error = if pred != *y { 1. } else { 0. };
+            let error = if pred != *y { 1 } else { 0 };
 
             predictions.push(pred);
             errors.push(error);
@@ -516,7 +516,7 @@ where D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64 + Send + Sync + Copy {
             if pred == *p {
                 continue;
             }
-            let error = if pred != *y { 1. } else { 0. };
+            let error = if pred != *y { 1 } else { 0 };
 
             self.k_error_count += error - *e;
             *p = pred;
@@ -559,7 +559,7 @@ where D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64 + Send + Sync + Copy {
                     }
 
                     // Update error.
-                    let error = if pred != *true_y { 1. } else { 0. };
+                    let error = if pred != *true_y { 1 } else { 0 };
 
                     let update = error - *old_error;
                     *old_error = error;
@@ -570,14 +570,14 @@ where D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64 + Send + Sync + Copy {
             })
             .collect();
 
-        self.k_error_count += error_updates?.iter().sum::<f64>();
+        self.k_error_count += error_updates?.iter().sum::<u32>();
 
         Ok(())
     }
 
     /// Returns the error for the current k.
     pub fn get_error(&self) -> f64 {
-        self.k_error_count / self.labels.len() as f64
+        self.k_error_count as f64 / self.labels.len() as f64
     }
     
     /// Returns the error count for the current k.

--- a/src/estimates/knn_utils.rs
+++ b/src/estimates/knn_utils.rs
@@ -1,0 +1,46 @@
+/// Computes the NN bound derived from Cover&Hart, given
+/// the error and the number of labels.
+pub fn nn_bound(error: f64, nlabels: usize) -> f64 {
+    let nl = nlabels as f64;
+    // Computing: (L-1)/L * (1 - (1 - L/(L-1)*error).sqrt())
+    // with error = min(error, rg).
+    let rg = (nl-1.)/nl;
+    match error {
+        e if e < rg => rg * (1. - (1. - nl/(nl-1.)*error).sqrt()),
+        _ => rg,
+    }
+}
+
+/// Stragegies for selecting `k` for k-NN given the number of
+/// training examples `n`.
+pub enum KNNStrategy {
+    NN,
+    FixedK(usize),
+    Ln,
+    Log10,
+    Custom(Box<dyn Fn(usize) -> usize>),
+}
+
+pub fn knn_strategy(strategy: KNNStrategy) -> Box<dyn Fn(usize) -> usize> {
+    match strategy {
+        KNNStrategy::NN => Box::new(move |_| 1),
+        KNNStrategy::FixedK(k) => Box::new(move |_| k),
+        KNNStrategy::Ln => Box::new(move |n|
+                                    next_odd(if n != 0 {
+                                                (n as f64).ln().ceil() as usize
+                                             } else { 1 })),
+        KNNStrategy::Log10 => Box::new(move |n|
+                                    next_odd(if n != 0 {
+                                                (n as f64).log10().ceil() as usize
+                                             } else { 1 })),
+        KNNStrategy::Custom(custom) => custom,
+    }
+}
+
+/// Returns `n` if `n` is odd, otherwise `n+1`.
+fn next_odd(n: usize) -> usize {
+    match n % 2 {
+        0 => n + 1,
+        _ => n,
+    }
+}

--- a/src/estimates/mod.rs
+++ b/src/estimates/mod.rs
@@ -1,12 +1,14 @@
 //! This module implements Bayes risk estimates, and heuristics for
 //! evaluating convergence.
 pub mod knn;
+pub mod knn_utils;
 pub mod frequentist;
 pub mod convergence;
 
 pub use self::knn::KNNEstimator;
 pub use self::frequentist::FrequentistEstimator;
 pub use self::convergence::ForwardChecker;
+pub use self::knn_utils::{KNNStrategy,knn_strategy,nn_bound};
 
 use Label;
 use ndarray::prelude::*;


### PR DESCRIPTION
Refactoring so that:
- all Bayes risk estimators (k-NN and frequentist) follow the same Trait
- KNNEstimator implements the logic for selecting k from n.
- main utils for k-NN are in knn_utils.rs.

Enabled to simplify main.rs as well.