### PR TITLE
Python module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ crate-type = ["cdylib", "rlib"]
 name = "fbleau"
 path = "src/main.rs"
 
+[features]
+# If enabled, it produces a Python module.
+python-module = ["pyo3", "numpy"]
+
 [dependencies]
 docopt = "1"
 itertools = "0.7.8"
@@ -27,8 +31,8 @@ ordered-float = "0.5.0"
 float-cmp = "0.5.2"
 strsim = "0.9.1"
 ndarray = "0.13.0"
-numpy = "0.7.0"
-pyo3 = { version = "0.8.2", features = ["extension-module"] }
+pyo3 = { version = "0.8.2", features = ["extension-module"], optional = true }
+numpy = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 rustlearn = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [
 [lib]
 name = "fbleau"
 path = "src/lib.rs"
+crate-type = ["cdylib", "rlib"]
 
 [[bin]]
 name = "fbleau"
@@ -26,6 +27,8 @@ ordered-float = "0.5.0"
 float-cmp = "0.5.2"
 strsim = "0.9.1"
 ndarray = "0.13.0"
+numpy = "0.7.0"
+pyo3 = { version = "0.8.2", features = ["extension-module"] }
 
 [dev-dependencies]
 rustlearn = "0.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,13 +38,16 @@ extern crate float_cmp;
 #[macro_use]
 extern crate serde;
 extern crate strsim;
+#[cfg(feature="python-module")]
 extern crate pyo3;
+#[cfg(feature="python-module")]
 extern crate numpy;
 
 pub mod estimates;
-pub mod python_module;
 pub mod fbleau_estimation;
 pub mod security_measures;
 pub mod utils;
+#[cfg(feature="python-module")]
+pub mod python_module;
 
 pub type Label = usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,11 @@ extern crate float_cmp;
 #[macro_use]
 extern crate serde;
 extern crate strsim;
+extern crate pyo3;
+extern crate numpy;
 
 pub mod estimates;
+pub mod python_module;
 pub mod fbleau_estimation;
 pub mod security_measures;
 pub mod utils;

--- a/src/python_module.rs
+++ b/src/python_module.rs
@@ -8,8 +8,32 @@ use Label;
 use estimates::*;
 use fbleau_estimation::run_fbleau;
 
+/// F-BLEAU is a tool for estimating the leakage of a system about its secrets
+/// in a black-box manner (i.e., by only looking at examples of secret inputs
+/// and respective outputs). It considers a generic system as a black-box,
+/// taking secret inputs and returning outputs accordingly, and it measures
+/// how much the outputs "leak" about the inputs.
 #[pymodule(fbleau)]
 fn pyfbleau(_py: Python, m: &PyModule) -> PyResult<()> {
+    /// run_fbleau(train_x, train_y, test_x, test_y, estimate, knn_strategy,
+    /// distance, logfile, delta, qstop, absolute, scale)
+    /// --
+    ///
+    /// Run F-BLEAU for the chosen estimate.
+    ///
+    /// Keyword arguments:
+    /// train_x : training observations
+    /// train_y : training secrets
+    /// test_x : test observations
+    /// test_y : test secrets
+    /// estimate : estimate, value in ("nn", "knn", "frequentist", "nn-bound")
+    /// knn_strategy : if estimate is "knn", specify one in ("ln", "log10")
+    /// distance : the distance used for NN or k-NN
+    /// logfile : if specified, log the estimate values at every step in this file
+    /// delta : use to stop fbleau when it reaches (delta, qstop)-convergence
+    /// qstop : use to stop fbleau when it reaches (delta, qstop)-convergence
+    /// absolute : measure absolute instead of relative convergence
+    /// scale : scale observations' features in [0,1]
 	#[pyfn(m, "run_fbleau")]
 	fn run_fbleau_py(_py: Python,
                      train_x: &PyArray2<f64>, train_y: &PyArray1<Label>,

--- a/src/python_module.rs
+++ b/src/python_module.rs
@@ -1,0 +1,53 @@
+//! A wrapper to allow calling fbleau from Python.
+//!
+//! Wraps the function `fbleau_estimation::run_fbleau()`.
+use numpy::*;
+use pyo3::prelude::*;
+
+use Label;
+use estimates::*;
+use fbleau_estimation::run_fbleau;
+
+#[pymodule(fbleau)]
+fn pyfbleau(_py: Python, m: &PyModule) -> PyResult<()> {
+	#[pyfn(m, "run_fbleau")]
+	fn run_fbleau_py(_py: Python,
+                     train_x: &PyArray2<f64>, train_y: &PyArray1<Label>,
+					 test_x: &PyArray2<f64>, test_y: &PyArray1<Label>,
+					 estimate: &str, knn_strategy: Option<&str>,
+					 distance: Option<String>, logfile: Option<String>,
+					 delta: Option<f64>, qstop: Option<usize>, absolute: bool,
+                     scale: bool)
+			-> (f64, f64, f64) {
+
+        // FIXME: Make run_fbleau() accept just a reference to them.
+		let train_x = train_x.as_array().to_owned();
+		let train_y = train_y.as_array().to_owned();
+		let test_x = test_x.as_array().to_owned();
+		let test_y = test_y.as_array().to_owned();
+
+        // TODO: a more compact way to do the following is by
+        // using serde's Deserialize (already implemented for Estimate
+        // and KNNStrategy).
+        let estimate = match estimate {
+            "nn" => Estimate::NN,
+            "knn" => Estimate::KNN,
+            "frequentist" => Estimate::Frequentist,
+            "nn-bound" => Estimate::NNBound,
+            _ => { unimplemented!() },
+        };
+        let knn_strategy = if let Some(strategy) = knn_strategy {
+            match strategy {
+                "ln" => Some(KNNStrategy::Ln),
+                "log10" => Some(KNNStrategy::Log10),
+                _ => { unimplemented!() },
+            }
+        } else {
+            None
+        };
+
+		run_fbleau(train_x, train_y, test_x, test_y, estimate, knn_strategy,
+				   distance, logfile, delta, qstop, absolute, scale)
+	}
+	Ok(())
+}


### PR DESCRIPTION
Adds a basic wrapper around fbleau, which can be used directly from Python. It can be built by (optionally) enabling the `python-module` feature.